### PR TITLE
Adds information to the AboutCommand regarding the active driver

### DIFF
--- a/config/exchange.php
+++ b/config/exchange.php
@@ -48,4 +48,15 @@ return [
             'key' => 'cached_exchange_rates',
         ],
     ],
+
+    'features' => [
+
+        /**
+         * Laravel's about command provides useful information regarding the state of
+         * your Laravel application. If `about_command` is set to true, we will
+         * show useful information about exchange in about command output.
+         */
+        'about_command' => true,
+
+    ]
 ];

--- a/src/ExchangeServiceProvider.php
+++ b/src/ExchangeServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Worksome\Exchange;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Console\AboutCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Worksome\Exchange\Actions\ValidateCurrencyCodes;
@@ -29,6 +30,8 @@ final class ExchangeServiceProvider extends PackageServiceProvider
 
         $this->app->bind(CurrencyCodeProvider::class, FlatCurrencyCodeProvider::class);
         $this->app->bind(ValidatesCurrencyCodes::class, ValidateCurrencyCodes::class);
+
+        $this->extendAboutCommand();
     }
 
     public function configurePackage(Package $package): void
@@ -40,5 +43,20 @@ final class ExchangeServiceProvider extends PackageServiceProvider
                 InstallCommand::class,
                 ViewLatestRatesCommand::class
             );
+    }
+
+    private function extendAboutCommand(): void
+    {
+        if (! class_exists(AboutCommand::class)) {
+            return;
+        }
+
+        if (! config('exchange.features.about_command', true)) {
+            return;
+        }
+
+        AboutCommand::add('Exchange', [
+            'Driver' => fn () => config('exchange.default'),
+        ]);
     }
 }

--- a/tests/Feature/Commands/AboutCommandTest.php
+++ b/tests/Feature/Commands/AboutCommandTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Console\AboutCommand;
+
+it('shows exchange details', function () {
+    $this->artisan('about')
+        ->assertSuccessful()
+        ->expectsOutputToContain('Exchange')
+        ->expectsOutputToContain('Driver');
+})->skip(! class_exists(AboutCommand::class));


### PR DESCRIPTION
<img width="1108" alt="CleanShot 2022-07-26 at 14 03 28@2x" src="https://user-images.githubusercontent.com/12202279/181012554-63d16ef8-71b7-4258-8338-c3388024e401.png">

The feature can be disabled by setting the `exchange.features.about_command` config variable to `false`. It is also automatically disabled in Laravel versions prior to the introduction of the `AboutCommand`.