### PR TITLE
Updated Frankfurter endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ Set `CURRENCY_GEO_ACCESS_KEY` to your provided access key from currency.getgeoap
 With that task completed, you're ready to start using [Currency.GetGeoApi.com](https://currency.getgeoapi.com) for retrieving up-to-date
 exchange rates.
 
-### Frankfurter.app
+### Frankfurter.dev
 
-[frankfurter.app](https://frankfurter.app) is an open-source API for current and historical foreign exchange rates published by the European Central Bank, which can be used without an API key.
+[frankfurter.dev](https://frankfurter.dev) is an open-source API for current and historical foreign exchange rates published by the European Central Bank, which can be used without an API key.
 
 In your `exchange.php` config file, set `default` to `frankfurter`, or set `EXCHANGE_DRIVER` to `frankfurter` in your `.env` file.
 
-With that task completed, you're ready to start using [frankfurter.app](https://frankfurter.app) for retrieving up-to-date
+With that task completed, you're ready to start using [frankfurter.dev](https://frankfurter.dev) for retrieving up-to-date
 exchange rates.
 
 ### Cache

--- a/src/ExchangeRateProviders/FrankfurterProvider.php
+++ b/src/ExchangeRateProviders/FrankfurterProvider.php
@@ -17,7 +17,7 @@ final class FrankfurterProvider implements ExchangeRateProvider
 {
     public function __construct(
         private Factory $client,
-        private string $baseUrl = 'https://api.frankfurter.app',
+        private string $baseUrl = 'https://api.frankfurter.dev/v1',
     ) {
     }
 

--- a/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
+++ b/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
@@ -31,7 +31,7 @@ it('makes a HTTP request to the correct endpoint', function () {
     $fixerProvider->getRates('EUR', currencies());
 
     $client->assertSent(function (Request $request) {
-        return str_starts_with($request->url(), 'https://api.frankfurter.app/latest');
+        return str_starts_with($request->url(), 'https://api.frankfurter.dev/v1/latest');
     });
 });
 


### PR DESCRIPTION
The endpoint for the Frankfurter API has been changed:
https://github.com/lineofflight/frankfurter/commit/35ff7d9c11211b39074424520b5cc69611a72876

The .app endpoint now seems a lot more unstable and is currently giving a lot of timeouts.