### PR TITLE
feat: update `Rates` to use readonly properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ In the example above, we are retrieving exchange rates for GBP and EUR based on 
 which includes the base currency, retrieved rates and the time of retrieval. Retrieved rates are an `array` with currency codes as keys and exchange rates as values.
 
 ```php
-$rates = $exchangeRates->getRates(); // ['GBP' => 1.0, 'EUR' => 1.0]
+/** @var \Worksome\Exchange\Support\Rates $exchangeRates */
+$rates = $exchangeRates->rates; // ['GBP' => 1.0, 'EUR' => 1.0]
 ```
 
 ### Fixer

--- a/src/Actions/ValidateCurrencyCodes.php
+++ b/src/Actions/ValidateCurrencyCodes.php
@@ -8,7 +8,7 @@ use Worksome\Exchange\Contracts\Actions\ValidatesCurrencyCodes;
 use Worksome\Exchange\Contracts\CurrencyCodeProvider;
 use Worksome\Exchange\Exceptions\InvalidCurrencyCodeException;
 
-final class ValidateCurrencyCodes implements ValidatesCurrencyCodes
+final readonly class ValidateCurrencyCodes implements ValidatesCurrencyCodes
 {
     public function __construct(private CurrencyCodeProvider $currencyCodeProvider)
     {

--- a/src/Commands/Concerns/HasUsefulConsoleMethods.php
+++ b/src/Commands/Concerns/HasUsefulConsoleMethods.php
@@ -8,9 +8,7 @@ use Illuminate\Console\Command;
 
 use function Termwind\render;
 
-/**
- * @mixin Command
- */
+/** @mixin Command */
 trait HasUsefulConsoleMethods
 {
     private function success(string $message): self

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -13,7 +13,7 @@ final class InstallCommand extends Command
 
     protected $signature = 'exchange:install';
 
-    protected $description = 'Publish Exchange\'s config file to your project.';
+    protected $description = "Publish Exchange's config file to your project.";
 
     public function handle(): int
     {

--- a/src/Commands/ViewLatestRatesCommand.php
+++ b/src/Commands/ViewLatestRatesCommand.php
@@ -29,7 +29,6 @@ final class ViewLatestRatesCommand extends Command
         $data = $this->data($currencyCodeProvider);
 
         try {
-            // @phpstan-ignore argument.type, argument.type
             $this->renderRates($exchange->rates($data['base_currency'], $data['currencies']));
         } catch (InvalidCurrencyCodeException $exception) {
             $this->newLine();
@@ -44,23 +43,28 @@ final class ViewLatestRatesCommand extends Command
         return self::SUCCESS;
     }
 
-    /**
-     * @return array<string, mixed>
-     */
+    /** @return array{base_currency: string, currencies: non-empty-list<string>} */
     private function data(CurrencyCodeProvider $currencyCodeProvider): array
     {
-        /** @var array<int, string> $givenCurrencies */
+        /** @var list<string> $givenCurrencies */
         $givenCurrencies = $this->argument('currencies');
 
+        $baseCurrency = $this->argument('base-currency') ?? $this->ask('Which base currency do you want to use?');
+
+        assert(is_string($baseCurrency));
+
+        /** @var list<string> $currencies */
+        $currencies = count($givenCurrencies) > 0 ? $givenCurrencies : $this->choice(
+            'Which currencies do you want to fetch exchange rates for?',
+            $currencyCodeProvider->all(),
+            multiple: true,
+        );
+
+        assert($currencies !== []);
+
         return [
-            'base_currency' => $this->argument('base-currency') ?? $this->ask(
-                'Which base currency do you want to use?'
-            ),
-            'currencies' => count($givenCurrencies) > 0 ? $givenCurrencies : $this->choice(
-                'Which currencies do you want to fetch exchange rates for?',
-                $currencyCodeProvider->all(),
-                multiple: true,
-            ),
+            'base_currency' => $baseCurrency,
+            'currencies' => $currencies,
         ];
     }
 
@@ -85,6 +89,6 @@ final class ViewLatestRatesCommand extends Command
                     @endforeach
                 </div>
             </div>
-        HTML, ['baseCurrency' => $rates->getBaseCurrency(), 'rates' => $rates->getRates()]));
+        HTML, ['baseCurrency' => $rates->baseCurrency, 'rates' => $rates->rates]));
     }
 }

--- a/src/Contracts/Actions/ValidatesCurrencyCodes.php
+++ b/src/Contracts/Actions/ValidatesCurrencyCodes.php
@@ -9,9 +9,9 @@ use Worksome\Exchange\Exceptions\InvalidCurrencyCodeException;
 interface ValidatesCurrencyCodes
 {
     /**
-     * @param non-empty-array<int, string> $currencyCodes
+     * @param non-empty-list<string> $currencyCodes
      *
-     * @return non-empty-array<int, string>
+     * @return non-empty-list<string>
      *
      * @throws InvalidCurrencyCodeException
      */

--- a/src/Contracts/CurrencyCodeProvider.php
+++ b/src/Contracts/CurrencyCodeProvider.php
@@ -6,8 +6,6 @@ namespace Worksome\Exchange\Contracts;
 
 interface CurrencyCodeProvider
 {
-    /**
-     * @return non-empty-array<int, string>
-     */
+    /** @return non-empty-list<string> */
     public function all(): array;
 }

--- a/src/Contracts/ExchangeRateProvider.php
+++ b/src/Contracts/ExchangeRateProvider.php
@@ -8,8 +8,6 @@ use Worksome\Exchange\Support\Rates;
 
 interface ExchangeRateProvider
 {
-    /**
-     * @param non-empty-array<int, string> $currencies
-     */
+    /** @param non-empty-list<string> $currencies */
     public function getRates(string $baseCurrency, array $currencies): Rates;
 }

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -13,7 +13,7 @@ use Worksome\Exchange\Testing\FakeExchangeRateProvider;
 final class Exchange
 {
     public function __construct(
-        private ValidatesCurrencyCodes $validateCurrencyCodes,
+        private readonly ValidatesCurrencyCodes $validateCurrencyCodes,
         private ExchangeRateProvider $exchangeRateProvider,
     ) {
     }
@@ -23,11 +23,11 @@ final class Exchange
      */
     public function fake(array $rates = []): void
     {
-        $this->exchangeRateProvider = (new FakeExchangeRateProvider())->defineRates($rates);
+        $this->exchangeRateProvider = new FakeExchangeRateProvider()->defineRates($rates);
     }
 
     /**
-     * @param non-empty-array<int, string> $currencies
+     * @param non-empty-list<string> $currencies
      *
      * @throws InvalidCurrencyCodeException
      */

--- a/src/ExchangeRateProviders/CachedProvider.php
+++ b/src/ExchangeRateProviders/CachedProvider.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Arr;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class CachedProvider implements ExchangeRateProvider
+final readonly class CachedProvider implements ExchangeRateProvider
 {
     public function __construct(
         private Repository $cache,

--- a/src/ExchangeRateProviders/CurrencyGEOProvider.php
+++ b/src/ExchangeRateProviders/CurrencyGEOProvider.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class CurrencyGEOProvider implements ExchangeRateProvider
+final readonly class CurrencyGEOProvider implements ExchangeRateProvider
 {
     public function __construct(
         private Factory $client,

--- a/src/ExchangeRateProviders/ExchangeRateHostProvider.php
+++ b/src/ExchangeRateProviders/ExchangeRateHostProvider.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Client\Factory;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class ExchangeRateHostProvider implements ExchangeRateProvider
+final readonly class ExchangeRateHostProvider implements ExchangeRateProvider
 {
     private FixerProvider $fixerProvider;
 

--- a/src/ExchangeRateProviders/FixerProvider.php
+++ b/src/ExchangeRateProviders/FixerProvider.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Collection;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class FixerProvider implements ExchangeRateProvider
+final readonly class FixerProvider implements ExchangeRateProvider
 {
     public function __construct(
         private Factory $client,

--- a/src/ExchangeRateProviders/FrankfurterProvider.php
+++ b/src/ExchangeRateProviders/FrankfurterProvider.php
@@ -13,7 +13,7 @@ use InvalidArgumentException;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class FrankfurterProvider implements ExchangeRateProvider
+final readonly class FrankfurterProvider implements ExchangeRateProvider
 {
     public function __construct(
         private Factory $client,

--- a/src/ExchangeRateProviders/NullProvider.php
+++ b/src/ExchangeRateProviders/NullProvider.php
@@ -7,7 +7,7 @@ namespace Worksome\Exchange\ExchangeRateProviders;
 use Worksome\Exchange\Contracts\ExchangeRateProvider;
 use Worksome\Exchange\Support\Rates;
 
-final class NullProvider implements ExchangeRateProvider
+final readonly class NullProvider implements ExchangeRateProvider
 {
     public function getRates(string $baseCurrency, array $currencies): Rates
     {

--- a/src/ExchangeServiceProvider.php
+++ b/src/ExchangeServiceProvider.php
@@ -25,7 +25,7 @@ final class ExchangeServiceProvider extends PackageServiceProvider
 
         $this->app->bind(
             ExchangeRateProvider::class,
-            fn (Application $app) => (new ExchangeRateManager($app))->driver()
+            fn (Application $app) => new ExchangeRateManager($app)->driver()
         );
 
         $this->app->bind(CurrencyCodeProvider::class, FlatCurrencyCodeProvider::class);

--- a/src/Support/FlatCurrencyCodeProvider.php
+++ b/src/Support/FlatCurrencyCodeProvider.php
@@ -8,6 +8,7 @@ use Worksome\Exchange\Contracts\CurrencyCodeProvider;
 
 final class FlatCurrencyCodeProvider implements CurrencyCodeProvider
 {
+    /** {@inheritdoc} */
     public function all(): array
     {
         return [

--- a/src/Support/Rates.php
+++ b/src/Support/Rates.php
@@ -5,32 +5,32 @@ declare(strict_types=1);
 namespace Worksome\Exchange\Support;
 
 use Carbon\CarbonInterface;
+use Deprecated;
 
-final class Rates
+final readonly class Rates
 {
-    /**
-     * @param non-empty-array<string, float> $rates
-     */
+    /** @param non-empty-array<string, float> $rates */
     public function __construct(
-        private string $baseCurrency,
-        private array $rates,
-        private CarbonInterface $retrievedAt,
+        public string $baseCurrency,
+        public array $rates,
+        public CarbonInterface $retrievedAt,
     ) {
     }
 
+    #[Deprecated('Use `baseCurrency` property instead.', since: '2.4.0')]
     public function getBaseCurrency(): string
     {
         return $this->baseCurrency;
     }
 
-    /**
-     * @return non-empty-array<string, float>
-     */
+    /** @return non-empty-array<string, float> */
+    #[Deprecated('Use `rates` property instead.', since: '2.4.0')]
     public function getRates(): array
     {
         return $this->rates;
     }
 
+    #[Deprecated('Use `retrievedAt` property instead.', since: '2.4.0')]
     public function getRetrievedAt(): CarbonInterface
     {
         return $this->retrievedAt;

--- a/src/Support/Rates.php
+++ b/src/Support/Rates.php
@@ -17,20 +17,20 @@ final readonly class Rates
     ) {
     }
 
-    #[Deprecated('Use `baseCurrency` property instead.', since: '2.4.0')]
+    #[Deprecated('Use `baseCurrency` property instead. This will be removed in 3.x', since: '2.5.0')]
     public function getBaseCurrency(): string
     {
         return $this->baseCurrency;
     }
 
     /** @return non-empty-array<string, float> */
-    #[Deprecated('Use `rates` property instead.', since: '2.4.0')]
+    #[Deprecated('Use `rates` property instead. This will be removed in 3.x', since: '2.5.0')]
     public function getRates(): array
     {
         return $this->rates;
     }
 
-    #[Deprecated('Use `retrievedAt` property instead.', since: '2.4.0')]
+    #[Deprecated('Use `retrievedAt` property instead. This will be removed in 3.x', since: '2.5.0')]
     public function getRetrievedAt(): CarbonInterface
     {
         return $this->retrievedAt;


### PR DESCRIPTION
This updates to use `readonly` public properties for `Rates`, and improves type hinting further.