### PR TITLE
feat: allow users to set a custom endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ exchange rates.
 
 In your `exchange.php` config file, set `default` to `frankfurter`, or set `EXCHANGE_DRIVER` to `frankfurter` in your `.env` file.
 
+If you are self-hosting Frankfurter or need to use a different endpoint, you can set `FRANKFURTER_BASE_URL` in your `.env` file. It defaults to `https://api.frankfurter.dev/v1`.
+
 With that task completed, you're ready to start using [frankfurter.dev](https://frankfurter.dev) for retrieving up-to-date
 exchange rates.
 

--- a/config/exchange.php
+++ b/config/exchange.php
@@ -60,6 +60,10 @@ return [
             'access_key' => env('CURRENCY_GEO_ACCESS_KEY'),
         ],
 
+        'frankfurter' => [
+            'endpoint' => env('FRANKFURTER_ENDPOINT', 'https://api.frankfurter.dev/v1'),
+        ],
+
         /*
         |--------------------------------------------------------------------------
         | Cache

--- a/config/exchange.php
+++ b/config/exchange.php
@@ -61,7 +61,7 @@ return [
         ],
 
         'frankfurter' => [
-            'endpoint' => env('FRANKFURTER_ENDPOINT', 'https://api.frankfurter.dev/v1'),
+            'base_url' => env('FRANKFURTER_BASE_URL', 'https://api.frankfurter.dev/v1'),
         ],
 
         /*

--- a/src/Support/ExchangeRateManager.php
+++ b/src/Support/ExchangeRateManager.php
@@ -74,6 +74,7 @@ final class ExchangeRateManager extends Manager
     {
         return new FrankfurterProvider(
             $this->container->make(Factory::class),
+            $this->config->string('exchange.services.frankfurter.endpoint', 'https://api.frankfurter.dev/v1'),
         );
     }
 

--- a/src/Support/ExchangeRateManager.php
+++ b/src/Support/ExchangeRateManager.php
@@ -72,9 +72,11 @@ final class ExchangeRateManager extends Manager
 
     public function createFrankfurterDriver(): FrankfurterProvider
     {
+        $baseUrl = $this->config->string('exchange.services.frankfurter.base_url', 'https://api.frankfurter.dev/v1');
+
         return new FrankfurterProvider(
             $this->container->make(Factory::class),
-            $this->config->string('exchange.services.frankfurter.base_url', 'https://api.frankfurter.dev/v1'),
+            $baseUrl,
         );
     }
 

--- a/src/Support/ExchangeRateManager.php
+++ b/src/Support/ExchangeRateManager.php
@@ -74,7 +74,7 @@ final class ExchangeRateManager extends Manager
     {
         return new FrankfurterProvider(
             $this->container->make(Factory::class),
-            $this->config->string('exchange.services.frankfurter.endpoint', 'https://api.frankfurter.dev/v1'),
+            $this->config->string('exchange.services.frankfurter.base_url', 'https://api.frankfurter.dev/v1'),
         );
     }
 

--- a/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
+++ b/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
@@ -66,7 +66,7 @@ it('sets the returned timestamp as the retrievedAt timestamp', function () {
     expect($rates->getRetrievedAt()->format('Ymd'))->toBe(now()->subDay()->format('Ymd'));
 });
 
-it('makes a HTTP request to a custom endpoint', function () {
+it('makes a HTTP request to a custom base url', function () {
     $client = new Factory();
     $client->fake(['*' => [
         'date' => now()->subDay()->format('Y-m-d'),

--- a/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
+++ b/tests/Unit/ExchangeRateProviders/FrankfurterProviderTest.php
@@ -66,6 +66,24 @@ it('sets the returned timestamp as the retrievedAt timestamp', function () {
     expect($rates->getRetrievedAt()->format('Ymd'))->toBe(now()->subDay()->format('Ymd'));
 });
 
+it('makes a HTTP request to a custom endpoint', function () {
+    $client = new Factory();
+    $client->fake(['*' => [
+        'date' => now()->subDay()->format('Y-m-d'),
+        'rates' => [
+            'EUR' => 1,
+            'GBP' => 2.5,
+        ],
+    ]]);
+
+    $fixerProvider = new FrankfurterProvider($client, 'https://custom.frankfurter.dev/v1');
+    $fixerProvider->getRates('EUR', currencies());
+
+    $client->assertSent(function (Request $request) {
+        return str_starts_with($request->url(), 'https://custom.frankfurter.dev/v1/latest');
+    });
+});
+
 it('throws a RequestException if a 500 error occurs', function () {
     $client = new Factory();
     $client->fake(['*' => Create::promiseFor(new Response(500))]);


### PR DESCRIPTION
You can [deploy](https://frankfurter.dev/deploy/) with Docker on your own platform. This means you need to be able to override the endpoint on which you will access its API. 

@owenvoke let me know if this fits your style or if you want to call it `FRANKFURTER_BASE_URL` as that's the name of the variable in the provider.